### PR TITLE
refactor: users API에서 cards API로 데이터 소스 변경 (Close #78)

### DIFF
--- a/src/app/(main)/my-card/page.tsx
+++ b/src/app/(main)/my-card/page.tsx
@@ -1,10 +1,18 @@
 'use client'
 
-import { useMyProfile } from '@/features/user'
+import { useMyInfo } from '@/features/user'
+import { useMyLatestCard, toProfileDataFromCard } from '@/features/qr-share'
 import { CardView } from '@/features/card-detail/ui'
 
 export default function MyCardPage() {
-  const { data: profileData, userInfo, isLoading, isError } = useMyProfile()
+  const {
+    data: cardData,
+    isLoading: isCardLoading,
+    isError: isCardError,
+  } = useMyLatestCard()
+  const { data: userInfo, isLoading: isUserLoading } = useMyInfo()
+
+  const isLoading = isCardLoading || isUserLoading
 
   if (isLoading) {
     return (
@@ -14,7 +22,7 @@ export default function MyCardPage() {
     )
   }
 
-  if (isError || !profileData) {
+  if (isCardError || !cardData) {
     return (
       <div className="bg-background flex min-h-screen items-center justify-center">
         <p className="text-muted-foreground">정보를 불러올 수 없습니다.</p>
@@ -22,10 +30,15 @@ export default function MyCardPage() {
     )
   }
 
+  const profileData = toProfileDataFromCard(
+    cardData,
+    userInfo?.profile_image_url
+  )
+
   return (
     <CardView
       profileData={profileData}
-      userInfo={userInfo}
+      userInfo={{ description: cardData.description } as any}
       showMenu={true}
       isOwner={true}
     />

--- a/src/features/qr-share/api/index.ts
+++ b/src/features/qr-share/api/index.ts
@@ -1,2 +1,6 @@
 export { getMyLatestCard } from './qr-share.api'
-export { useMyLatestCard, qrShareKeys } from './qr-share.queries'
+export {
+  useMyLatestCard,
+  qrShareKeys,
+  toProfileDataFromCard,
+} from './qr-share.queries'

--- a/src/features/qr-share/api/qr-share.queries.ts
+++ b/src/features/qr-share/api/qr-share.queries.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
+import type { ProfileData } from '@/shared'
 import { getMyLatestCard } from './qr-share.api'
+import type { CardData } from '../model'
 
 /** 쿼리 키 */
 export const qrShareKeys = {
@@ -28,4 +30,21 @@ export function useMyLatestCard() {
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
   })
+}
+
+/** CardData를 ProfileData로 변환 */
+export function toProfileDataFromCard(
+  cardData: CardData,
+  profileImageUrl?: string
+): ProfileData {
+  return {
+    name: cardData.name,
+    email: cardData.email,
+    phone: cardData.phone_number,
+    tel: cardData.lined_number,
+    company: cardData.company,
+    department: cardData.department,
+    position: cardData.position,
+    avatarSrc: profileImageUrl || null,
+  }
 }

--- a/src/features/qr-share/index.ts
+++ b/src/features/qr-share/index.ts
@@ -1,5 +1,5 @@
 // API
-export { useMyLatestCard, qrShareKeys } from './api'
+export { useMyLatestCard, qrShareKeys, toProfileDataFromCard } from './api'
 
 // Model
 export type { CardData, MyLatestCardResponse } from './model'

--- a/src/features/qr-share/model/types.ts
+++ b/src/features/qr-share/model/types.ts
@@ -23,4 +23,5 @@ export interface CardData {
   end_date: string
   is_progress: string
   ai_card_image_url: string
+  description: string
 }


### PR DESCRIPTION
**Title**
  refactor: users API에서 cards API로 데이터 소스 변경 

**Body**
#### 요약
  - 내 명함 페이지에서 `/api/users/me` 대신 `/api/cards/me/latest` API를 사용하도록 변경
  - 프로필 이미지만 기존 `/api/users/me`에서 가져오고, 나머지 데이터는 cards API 응답 사용

#### 완료 범위(필수)

- [x] 내 명함 페이지 데이터 소스 변경 완료
- [x] `toProfileDataFromCard` 순수 함수 추가로 서버 컴포넌트 전환 용이하게 설계
- [x] `CardData` 타입에 `description` 필드 추가

#### 변경 내용
  - `src/app/(main)/my-card/page.tsx`: `useMyProfile` → `useMyLatestCard` + `useMyInfo` 분리 호출
  - `src/features/qr-share/api/qr-share.queries.ts`: `toProfileDataFromCard` 변환 함수 추가
  - `src/features/qr-share/model/types.ts`: `CardData` 인터페이스에 `description` 필드 추가
  - export 경로 업데이트 (`api/index.ts`, `qr-share/index.ts`)

#### 테스트/검증
  - [x] 내 명함 페이지 접속 시 Network 탭에서 `/api/cards/me/latest` 호출 확인
  - [x] 프로필 이미지가 `/api/users/me`의 `profile_image_url`로 표시되는지 확인
  - [x] 이름, 이메일, 전화번호, 회사, 부서, 직책이 cards API 응답에서 표시되는지 확인
  - [ ] AI 설명(description)이 GlassCardPreview에서 정상 표시되는지 확인