### PR TITLE
fix: 카메라 권한 상태(setStatus)를 전역상태관리(Jotai)로 관리 (Close #85)

### DIFF
--- a/src/features/qr-scan/model/camera-permission.atom.ts
+++ b/src/features/qr-scan/model/camera-permission.atom.ts
@@ -1,0 +1,5 @@
+import { atom } from 'jotai'
+
+export type CameraPermissionState = 'unknown' | 'granted' | 'denied' | 'prompt'
+
+export const cameraPermissionAtom = atom<CameraPermissionState>('unknown')

--- a/src/features/qr-scan/model/index.ts
+++ b/src/features/qr-scan/model/index.ts
@@ -4,3 +4,6 @@ export type {
   ScannedCardData,
   QrScanStatus,
 } from './types'
+
+export { cameraPermissionAtom } from './camera-permission.atom'
+export type { CameraPermissionState } from './camera-permission.atom'


### PR DESCRIPTION
### 제목(Title)
fix: 카메라 권한 상태(setStatus)를 전역상태관리(Jotai)로 관리

---

### 본문(Body)
#### 요약
 - QR 스캔 페이지에서 카메라 권한 거부 후 "돌아가기" → 재진입 시 스캐너가 비활성화된 화면이 표시되던 버그 수정
 - Jotai atom으로 카메라 권한 상태를 전역 관리하여, 권한 거부 상태를 기억하도록 개선

#### 완료 범위(필수)
- [x] 카메라 권한 거부 상태가 Jotai atom에 저장됨
- [x] 재진입 시 저장된 권한 상태를 확인하여 바로 에러 화면(`CameraPermissionError`) 표시
- [x] `qr-scan-page.tsx`와 `qr-scan-guide.tsx` 모두 동일하게 적용

#### 변경 내용
 - `camera-permission.atom.ts` 신규 생성 (권한 상태 atom)
 - `model/index.ts`에 export 추가
 - `qr-scan-page.tsx`에 권한 상태 체크 로직 추가
 - `qr-scan-guide.tsx`에 권한 상태 체크 로직 추가

#### 테스트/검증
- [x] 카메라 권한 거부 → "돌아가기" 클릭 → QR 스캔 재시도 시 `CameraPermissionError` 화면 즉시 표시 확인