### PR TITLE
fix: 상대 명함 조회 api 연결 수정 (Close #88)

### DIFF
--- a/src/features/career-edit/api/career.api.ts
+++ b/src/features/career-edit/api/career.api.ts
@@ -11,6 +11,7 @@ export interface CareerResponse {
   company: string | null
   position: string | null
   department: string | null
+  description: string | null
   start_date: string
   end_date: string | null
   is_progress: boolean

--- a/src/features/user/api/user.queries.ts
+++ b/src/features/user/api/user.queries.ts
@@ -2,6 +2,7 @@ import React from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type { ProfileData } from '@/shared'
 import { getMyInfo, getUserProfile } from './user.api'
+import { getCareersByUserId } from '@/features/career-edit/api/career.api'
 import type { UserInfo } from '../model'
 
 /** 쿼리 키 */
@@ -63,12 +64,13 @@ export function useInvalidateMyInfo() {
   }
 }
 
-/** 특정 유저 프로필 조회 훅 */
+/** 특정 유저 프로필 조회 훅 (이미지는 users API, 나머지는 cards API) */
 export function useUserProfile(
   userId: string,
   options?: { enabled?: boolean }
 ) {
-  const query = useQuery({
+  // 프로필 조회 (이미지용)
+  const profileQuery = useQuery({
     queryKey: userKeys.profile(userId),
     queryFn: async () => {
       const response = await getUserProfile(userId)
@@ -79,14 +81,48 @@ export function useUserProfile(
     gcTime: 10 * 60 * 1000,
   })
 
-  const profileData = React.useMemo(
-    () => (query.data ? toProfileData(query.data) : undefined),
-    [query.data]
-  )
+  // 카드 조회 (나머지 정보용)
+  const cardQuery = useQuery({
+    queryKey: [...userKeys.all, 'cards', userId],
+    queryFn: async () => {
+      const response = await getCareersByUserId(userId)
+      return response.data
+    },
+    enabled: options?.enabled !== false && Boolean(userId),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  })
+
+  const latestCard = cardQuery.data?.[0]
+
+  const profileData = React.useMemo(() => {
+    if (!latestCard) return undefined
+    return {
+      name: latestCard.name || '',
+      email: latestCard.email,
+      phone: latestCard.phone_number,
+      tel: latestCard.lined_number || '',
+      company: latestCard.company || '',
+      department: latestCard.department || '',
+      position: latestCard.position || '',
+      avatarSrc: profileQuery.data?.profile_image_url || null,
+    } as ProfileData
+  }, [latestCard, profileQuery.data])
+
+  // userInfo에 description도 cards에서 가져온 값으로 덮어씀
+  const userInfo = React.useMemo(() => {
+    if (!profileQuery.data) return undefined
+    return {
+      ...profileQuery.data,
+      description: latestCard?.description || profileQuery.data.description,
+    } as UserInfo
+  }, [profileQuery.data, latestCard])
 
   return {
-    ...query,
+    ...profileQuery,
     data: profileData,
-    userInfo: query.data,
+    userInfo,
+    isLoading: profileQuery.isLoading || cardQuery.isLoading,
+    isError: profileQuery.isError || cardQuery.isError,
   }
 }


### PR DESCRIPTION
### 제목(Title)
fix: 상대 명함 조회 api 연결 수정

---

### 본문(Body)
기존 프로필 api 연동 상태에서 프로필의 역할을 이미지 수정으로 축소하면서 api 연결도 같이 수정되었어야 했습니다.
이에 명함 조회 api 로 연결하였습니다.