### PR TITLE
feat: 비회원 명함 상세 조회 페이지 추가 및 홈 카드 라우팅 분기 (Close #133)

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -71,6 +71,15 @@ export default function HomePage() {
     setKeyword(value)
   }
 
+  const handleCardPress = (cardId: number, userId: number | null) => {
+    if (userId !== null) {
+      router.push(`/user/${userId}`)
+      return
+    }
+
+    router.push(`/cards/ocr/${cardId}`)
+  }
+
   return (
     <div className="flex min-h-dvh flex-col">
       {/* 헤더: 로고 + 프로필 버튼 */}
@@ -132,7 +141,7 @@ export default function HomePage() {
                 email={card.email}
                 lined_number={card.lined_number}
                 colorIndex={index}
-                onPress={() => router.push(`/user/${card.user_id}`)}
+                onPress={() => handleCardPress(card.id, card.user_id)}
                 onDelete={() => handleDelete(card.id)}
               />
             ))}

--- a/src/app/(main)/my-card/page.tsx
+++ b/src/app/(main)/my-card/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense } from 'react'
 import { PlusCircleIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Header } from '@/shared'
@@ -10,7 +11,7 @@ import { useMyLatestCard, toProfileDataFromCard } from '@/features/qr-share'
 import { CardView } from '@/features/card-detail/ui'
 import { cn } from '@/lib/utils'
 
-export default function MyCardPage() {
+function MyCardPageContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const {
@@ -102,5 +103,21 @@ export default function MyCardPage() {
       isOwner={true}
       initialActiveTab={initialActiveTab}
     />
+  )
+}
+
+function MyCardPageFallback() {
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center">
+      <p className="text-muted-foreground">로딩 중...</p>
+    </div>
+  )
+}
+
+export default function MyCardPage() {
+  return (
+    <Suspense fallback={<MyCardPageFallback />}>
+      <MyCardPageContent />
+    </Suspense>
   )
 }

--- a/src/app/(main)/my-card/page.tsx
+++ b/src/app/(main)/my-card/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { PlusCircleIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Header } from '@/shared'
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils'
 
 export default function MyCardPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const {
     data: cardData,
     isLoading: isCardLoading,
@@ -20,6 +21,11 @@ export default function MyCardPage() {
   const { data: userInfo, isLoading: isUserLoading } = useMyInfo()
 
   const isLoading = isCardLoading || isUserLoading
+  const tab = searchParams.get('tab')
+  const initialActiveTab =
+    tab === 'user-detail' || tab === 'charts' || tab === 'reviews'
+      ? tab
+      : undefined
 
   if (isLoading) {
     return (
@@ -94,6 +100,7 @@ export default function MyCardPage() {
       userInfo={{ description: cardData.description } as any}
       showMenu={true}
       isOwner={true}
+      initialActiveTab={initialActiveTab}
     />
   )
 }

--- a/src/app/bff/[...path]/route.ts
+++ b/src/app/bff/[...path]/route.ts
@@ -36,7 +36,7 @@ import {
 export const runtime = 'nodejs'
 
 type RouteParams = { path: string[] }
-type RouteContext = { params: Promise<RouteParams> | RouteParams }
+type RouteContext = { params: Promise<RouteParams> }
 
 function hasRequestBody(method: string): boolean {
   return !['GET', 'HEAD'].includes(method.toUpperCase())

--- a/src/app/cards/ocr/[id]/page.tsx
+++ b/src/app/cards/ocr/[id]/page.tsx
@@ -19,7 +19,11 @@ export default function OcrCardPage() {
   const params = useParams()
   const cardId = params.id as string
 
-  const { data: card, isLoading, isError } = useCareer(cardId, {
+  const {
+    data: card,
+    isLoading,
+    isError,
+  } = useCareer(cardId, {
     enabled: Boolean(cardId),
   })
 

--- a/src/app/cards/ocr/[id]/page.tsx
+++ b/src/app/cards/ocr/[id]/page.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import { useCareer } from '@/features/career-edit'
+import { CardView } from '@/features/card-detail/ui'
+import type { CareerItem } from '@/features/user-detail'
+import type { UserInfo } from '@/features/user/model'
+import type { ProfileData } from '@/shared'
+
+function formatDateToMonth(dateString: string | null | undefined): string {
+  if (!dateString) return ''
+  const date = new Date(dateString)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  return `${year}.${month}`
+}
+
+export default function OcrCardPage() {
+  const params = useParams()
+  const cardId = params.id as string
+
+  const { data: card, isLoading, isError } = useCareer(cardId, {
+    enabled: Boolean(cardId),
+  })
+
+  if (isLoading) {
+    return (
+      <div className="bg-background flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground">로딩 중...</p>
+      </div>
+    )
+  }
+
+  if (isError || !card) {
+    return (
+      <div className="bg-background flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground">정보를 불러올 수 없습니다.</p>
+      </div>
+    )
+  }
+
+  const profileData: ProfileData = {
+    name: card.name || '',
+    email: card.email,
+    phone: card.phone_number,
+    tel: card.lined_number || '',
+    company: card.company || '',
+    department: card.department || '',
+    position: card.position || '',
+    avatarSrc: null,
+  }
+
+  const start = formatDateToMonth(card.start_date)
+  const end = formatDateToMonth(card.end_date)
+  const period = card.is_progress
+    ? `${start} - 현재`
+    : end
+      ? `${start} - ${end}`
+      : start
+
+  const careerItems: CareerItem[] = [
+    {
+      id: String(card.id),
+      company: card.company || '',
+      position: card.position || '',
+      period,
+      description: card.department || undefined,
+    },
+  ]
+
+  return (
+    <CardView
+      profileData={profileData}
+      userInfo={{ description: card.description || '' } as UserInfo}
+      careerItemsOverride={careerItems}
+      showMenu={false}
+      isOwner={false}
+    />
+  )
+}

--- a/src/features/card-detail/ui/card-view.tsx
+++ b/src/features/card-detail/ui/card-view.tsx
@@ -111,6 +111,7 @@ interface CardViewProps {
   careerItemsOverride?: CareerItem[]
   showMenu?: boolean
   isOwner?: boolean
+  initialActiveTab?: NavTab
 }
 
 function CardView({
@@ -120,13 +121,14 @@ function CardView({
   careerItemsOverride,
   showMenu = false,
   isOwner = false,
+  initialActiveTab,
 }: CardViewProps) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [isFlip, setIsFlip] = React.useState(false)
   const [isCreatingDmRoom, setIsCreatingDmRoom] = React.useState(false)
   const [activeTab, setActiveTab] = React.useState<NavTab | undefined>(
-    undefined
+    initialActiveTab
   )
   const targetUserId = React.useMemo(() => {
     if (!userId) return null

--- a/src/features/card-detail/ui/card-view.tsx
+++ b/src/features/card-detail/ui/card-view.tsx
@@ -108,6 +108,7 @@ interface CardViewProps {
   profileData: ProfileData
   userInfo?: UserInfo
   userId?: string
+  careerItemsOverride?: CareerItem[]
   showMenu?: boolean
   isOwner?: boolean
 }
@@ -116,6 +117,7 @@ function CardView({
   profileData,
   userInfo,
   userId,
+  careerItemsOverride,
   showMenu = false,
   isOwner = false,
 }: CardViewProps) {
@@ -142,7 +144,7 @@ function CardView({
   const deleteCareerMutation = useDeleteCareer()
 
   // API 응답을 CareerItem 형식으로 변환
-  const careerItems: CareerItem[] = React.useMemo(() => {
+  const careerItemsFromApi: CareerItem[] = React.useMemo(() => {
     if (!careersData) return []
     return careersData.map((career) => ({
       id: String(career.id),
@@ -154,6 +156,8 @@ function CardView({
       description: career.department || undefined,
     }))
   }, [careersData])
+
+  const careerItems = careerItemsOverride ?? careerItemsFromApi
 
   // AI 설명 (API의 description 필드 사용)
   const aiDescription = userInfo?.description || ''

--- a/src/features/home/model/wallet.types.ts
+++ b/src/features/home/model/wallet.types.ts
@@ -1,7 +1,7 @@
 export interface WalletCard {
   id: number
   uuid: string
-  user_id: number
+  user_id: number | null
   name: string
   email: string
   phone_number: string

--- a/src/features/ocr/ui/ocr-result-page.tsx
+++ b/src/features/ocr/ui/ocr-result-page.tsx
@@ -175,7 +175,9 @@ function OcrResultPage() {
       if (mode === 'SELF') {
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: careerKeys.lists() }),
-          queryClient.invalidateQueries({ queryKey: qrShareKeys.myLatestCard() }),
+          queryClient.invalidateQueries({
+            queryKey: qrShareKeys.myLatestCard(),
+          }),
         ])
 
         await Promise.allSettled([

--- a/src/features/ocr/ui/ocr-result-page.tsx
+++ b/src/features/ocr/ui/ocr-result-page.tsx
@@ -2,11 +2,16 @@
 
 import * as React from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Controller, useForm } from 'react-hook-form'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
+import { getCareers, careerKeys } from '@/features/career-edit'
+import { walletKeys } from '@/features/home/api'
+import { getMyLatestCard, qrShareKeys } from '@/features/qr-share/api'
 import { Button, DateRangePicker, Field, Header, toast } from '@/shared'
 import { getOcrJobResult, submitOcrResult } from '../api'
 import { ocrFlowAtom, type OcrJobResult, type OcrMode } from '../model'
@@ -48,6 +53,7 @@ function toFormData(result: OcrJobResult): OcrResultFormData {
 function OcrResultPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const queryClient = useQueryClient()
   const taskId = searchParams.get('task_id')
 
   const [ocrFlow, setOcrFlow] = useAtom(ocrFlowAtom)
@@ -165,7 +171,46 @@ function OcrResultPage() {
       })
       toast.success('명함 정보가 저장되었습니다.')
       setOcrFlow({ mode: null, capturedImageUrl: null })
-      router.replace(mode === 'SELF' ? '/my-card' : '/home')
+
+      if (mode === 'SELF') {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: careerKeys.lists() }),
+          queryClient.invalidateQueries({ queryKey: qrShareKeys.myLatestCard() }),
+        ])
+
+        await Promise.allSettled([
+          queryClient.fetchQuery({
+            queryKey: careerKeys.list(),
+            queryFn: async () => {
+              const response = await getCareers()
+              return response.data
+            },
+          }),
+          queryClient.fetchQuery({
+            queryKey: qrShareKeys.myLatestCard(),
+            queryFn: async () => {
+              try {
+                const response = await getMyLatestCard()
+                return response.data ?? null
+              } catch (error) {
+                if (
+                  error instanceof AxiosError &&
+                  error.response?.status === 404
+                ) {
+                  return null
+                }
+                throw error
+              }
+            },
+          }),
+        ])
+
+        router.replace('/my-card?tab=user-detail')
+        return
+      }
+
+      await queryClient.invalidateQueries({ queryKey: walletKeys.all })
+      router.replace('/home')
     } catch (error) {
       console.error('Failed to submit OCR result:', error)
       toast.error('명함 저장 중 오류가 발생했습니다.')


### PR DESCRIPTION
### 제목(Title)

feat: 비회원 명함 상세 조회 페이지 추가 및 홈 카드 라우팅 분기

  ### 본문(Body)

  #### 요약

  홈 명함 목록에서 user_id 유무에 따라 이동 경로를 분기하고, 
  비회원 (OCR/paper card) 명함을 조회할 수 있는 전용 상세 페이지를 추가했습니다.

  #### 완료 범위(필수)

  - 홈 카드 클릭 시 회원/비회원 라우팅 분기 처리
  - 비회원 명함 상세 페이지(/cards/ocr/[id]) 신규 추가
  - user_id nullable 대응을 위한 타입 수정
  - 기존 CardView를 재사용할 수 있도록 경력 데이터 오버라이드 확장

  #### 변경 내용

  - src/app/(main)/home/page.tsx
      - handleCardPress(cardId, userId) 추가
      - userId !== null이면 /user/{userId}, 아니면 /cards/ocr/{cardId}로 이동
  - src/features/home/model/wallet.types.ts
      - WalletCard.user_id 타입을 number | null로 변경
  - src/features/card-detail/ui/card-view.tsx
      - careerItemsOverride?: CareerItem[] props 추가
      - API 기반 경력 대신 외부 주입 경력 데이터 사용 가능하도록 확장
  - src/app/cards/ocr/[id]/page.tsx (신규)
      - useCareer(cardId)로 비회원 명함 데이터 조회
      - 조회 결과를 ProfileData, CareerItem[]로 매핑해 CardView 렌더링
      - 로딩/에러 상태 UI 처리

  #### 테스트/검증

  - 홈 목록 카드 클릭 검증
      - user_id가 있는 카드: /user/{userId} 이동
      - user_id가 null인 카드: /cards/ocr/{cardId} 이동
  - 비회원 상세 페이지 검증
      - 데이터 로딩 성공 시 명함 정보/경력 정보 정상 노출
      - 로딩 중/에러 시 상태 메시지 정상 노출
  - 타입 검증
      - user_id: null 데이터 수신 시 타입 에러 없이 동작 확인