### PR TITLE
fix: BFF concurrent refresh race condition 해결 (Close #144)

### DIFF
--- a/src/app/bff/[...path]/route.ts
+++ b/src/app/bff/[...path]/route.ts
@@ -4,7 +4,7 @@ import { isAiPath, proxyAiRequest } from '@/server/bff/ai-router'
 import {
   buildSessionFingerprint,
   extractTokenPairFromBody,
-  refreshSessionViaSpring,
+  refreshSessionWithSingleFlight,
 } from '@/server/bff/auth-flow'
 import {
   isInternalOnlyPath,
@@ -302,7 +302,10 @@ async function handleProxyRequest(
       return unauthorized
     }
 
-    const refreshed = await refreshSessionViaSpring(sessionId, activeSession)
+    const refreshed = await refreshSessionWithSingleFlight(
+      sessionId,
+      activeSession
+    )
     if (!refreshed) {
       await deleteSession(sessionId)
       const unauthorized = await toProxyResponse(upstream)

--- a/src/app/bff/[...path]/route.ts
+++ b/src/app/bff/[...path]/route.ts
@@ -77,6 +77,18 @@ async function toProxyResponse(upstream: Response): Promise<NextResponse> {
   })
 }
 
+async function slideSession(
+  sessionId: string,
+  response: NextResponse
+): Promise<void> {
+  try {
+    await touchSession(sessionId)
+    issueSessionCookie(response, sessionId)
+  } catch {
+    // 응답 성공을 깨지 않기 위해 sliding 갱신 실패는 무시한다.
+  }
+}
+
 async function resolveApiPath(context: RouteContext): Promise<string> {
   const params = await Promise.resolve(context.params)
   return `/${params.path.join('/')}`
@@ -117,11 +129,7 @@ async function handleAiProxy(
   })
 
   if (response.ok) {
-    try {
-      await touchSession(sessionId)
-    } catch {
-      // 응답 성공을 깨지 않기 위해 TTL 갱신 실패는 무시한다.
-    }
+    await slideSession(sessionId, response)
   }
 
   return response
@@ -332,11 +340,7 @@ async function handleProxyRequest(
   }
 
   if (sessionId && upstream.ok) {
-    try {
-      await touchSession(sessionId)
-    } catch {
-      // 응답 성공을 깨지 않기 위해 TTL 갱신 실패는 무시한다.
-    }
+    await slideSession(sessionId, response)
   }
 
   return response

--- a/src/server/bff/auth-flow.ts
+++ b/src/server/bff/auth-flow.ts
@@ -1,8 +1,13 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import type { NextRequest } from 'next/server'
 import { forwardToSpring } from '@/server/bff/spring-client'
+import { getServerEnv } from '@/server/config/env'
+import {
+  redisReleaseLockIfOwner,
+  redisSetNxPx,
+} from '@/server/redis/client'
 import type { SessionRecord } from '@/server/session/store'
-import { updateSessionTokens } from '@/server/session/store'
+import { getSession, updateSessionTokens } from '@/server/session/store'
 
 interface TokenPair {
   accessToken: string
@@ -57,6 +62,28 @@ function toSha256(value: string | null): string | undefined {
   return createHash('sha256').update(value).digest('hex')
 }
 
+function buildRefreshLockKey(sessionId: string): string {
+  const { redisNamespace } = getServerEnv()
+  return `${redisNamespace}:refresh-lock:${sessionId}`
+}
+
+function hasSessionRotated(
+  staleSession: SessionRecord,
+  latestSession: SessionRecord
+): boolean {
+  return (
+    staleSession.accessToken !== latestSession.accessToken ||
+    staleSession.refreshToken !== latestSession.refreshToken ||
+    staleSession.lastRotatedAt !== latestSession.lastRotatedAt
+  )
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
 export function buildSessionFingerprint(
   request: NextRequest
 ): Pick<SessionRecord, 'userAgentHash' | 'ipHash'> {
@@ -101,4 +128,59 @@ export async function refreshSessionViaSpring(
     nextTokenPair.accessToken,
     nextTokenPair.refreshToken
   )
+}
+
+export async function refreshSessionWithSingleFlight(
+  sessionId: string,
+  staleSession: SessionRecord
+): Promise<SessionRecord | null> {
+  const env = getServerEnv()
+  const lockKey = buildRefreshLockKey(sessionId)
+  const deadline = Date.now() + env.refreshSingleFlightWaitMs
+
+  while (Date.now() < deadline) {
+    const latestSession = await getSession(sessionId)
+    if (!latestSession) return null
+
+    if (hasSessionRotated(staleSession, latestSession)) {
+      return latestSession
+    }
+
+    const lockOwner = randomUUID()
+    const acquired = await redisSetNxPx(
+      lockKey,
+      lockOwner,
+      env.refreshSingleFlightLockMs
+    )
+
+    if (acquired) {
+      try {
+        const currentSession = await getSession(sessionId)
+        if (!currentSession) return null
+
+        if (hasSessionRotated(staleSession, currentSession)) {
+          return currentSession
+        }
+
+        return refreshSessionViaSpring(sessionId, currentSession)
+      } finally {
+        try {
+          await redisReleaseLockIfOwner(lockKey, lockOwner)
+        } catch {
+          // 락 해제 실패는 다음 요청에서 TTL 만료로 복구된다.
+        }
+      }
+    }
+
+    await sleep(env.refreshSingleFlightPollMs)
+  }
+
+  const latestSession = await getSession(sessionId)
+  if (!latestSession) return null
+
+  if (hasSessionRotated(staleSession, latestSession)) {
+    return latestSession
+  }
+
+  return null
 }

--- a/src/server/bff/auth-flow.ts
+++ b/src/server/bff/auth-flow.ts
@@ -2,10 +2,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import type { NextRequest } from 'next/server'
 import { forwardToSpring } from '@/server/bff/spring-client'
 import { getServerEnv } from '@/server/config/env'
-import {
-  redisReleaseLockIfOwner,
-  redisSetNxPx,
-} from '@/server/redis/client'
+import { redisReleaseLockIfOwner, redisSetNxPx } from '@/server/redis/client'
 import type { SessionRecord } from '@/server/session/store'
 import { getSession, updateSessionTokens } from '@/server/session/store'
 

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -8,6 +8,9 @@ export interface ServerEnv {
   sessionTtlSeconds: number
   maxSessionLifetime: number
   minRotationInterval: number
+  refreshSingleFlightLockMs: number
+  refreshSingleFlightWaitMs: number
+  refreshSingleFlightPollMs: number
 }
 
 const DEFAULT_REDIS_NAMESPACE = 'caro:local'
@@ -19,6 +22,9 @@ const DEFAULT_MAX_SESSION_LIFETIME = 7 * 24 * 60 * 60 // 7d
 
 // rotation
 const DEFAULT_MIN_ROTATION_INTERVAL = 5 // seconds
+const DEFAULT_REFRESH_SINGLE_FLIGHT_LOCK_MS = 8000
+const DEFAULT_REFRESH_SINGLE_FLIGHT_WAIT_MS = 10000
+const DEFAULT_REFRESH_SINGLE_FLIGHT_POLL_MS = 100
 
 function readBoolean(value: string | undefined, fallback: boolean): boolean {
   if (!value) return fallback
@@ -71,6 +77,19 @@ export function getServerEnv(): ServerEnv {
     minRotationInterval: readPositiveInt(
       process.env.MIN_ROTATION_INTERVAL,
       DEFAULT_MIN_ROTATION_INTERVAL
+    ),
+
+    refreshSingleFlightLockMs: readPositiveInt(
+      process.env.REFRESH_SINGLE_FLIGHT_LOCK_MS,
+      DEFAULT_REFRESH_SINGLE_FLIGHT_LOCK_MS
+    ),
+    refreshSingleFlightWaitMs: readPositiveInt(
+      process.env.REFRESH_SINGLE_FLIGHT_WAIT_MS,
+      DEFAULT_REFRESH_SINGLE_FLIGHT_WAIT_MS
+    ),
+    refreshSingleFlightPollMs: readPositiveInt(
+      process.env.REFRESH_SINGLE_FLIGHT_POLL_MS,
+      DEFAULT_REFRESH_SINGLE_FLIGHT_POLL_MS
     ),
   }
 }

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -45,3 +45,32 @@ export async function redisExpire(
 export async function redisDel(key: string): Promise<number> {
   return getRedisClient().del(key)
 }
+
+const RELEASE_LOCK_IF_OWNER_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`
+
+export async function redisSetNxPx(
+  key: string,
+  value: string,
+  ttlMs: number
+): Promise<boolean> {
+  const result = await getRedisClient().set(key, value, 'PX', ttlMs, 'NX')
+  return result === 'OK'
+}
+
+export async function redisReleaseLockIfOwner(
+  key: string,
+  owner: string
+): Promise<boolean> {
+  const result = await getRedisClient().eval(
+    RELEASE_LOCK_IF_OWNER_SCRIPT,
+    1,
+    key,
+    owner
+  )
+  return Number(result) === 1
+}


### PR DESCRIPTION
### 제목
fix: BFF concurrent refresh race condition 해결: Redis single-flight refresh 도입

### 본문
#### 요약
- 동시 401 요청에서 동일 세션의 refresh가 중복 실행되며 RT rotation 충돌(lookupKey not found)로 세션이 삭제되고 로그인 페이지로 이동하던 문제를 해결했습니다.
- 세션 단위 Redis single-flight(lock)로 refresh를 동시에 1회만 수행하고, 나머지 요청은 갱신된 세션을 재조회해 재사용하도록 변경했습니다.

#### 완료 범위
- [x] BFF refresh 오케스트레이션 개선
- [x] Redis lock 유틸 추가
- [x] BFF 라우트 refresh 호출 경로 교체
- [x] single-flight 관련 환경설정 추가(기본값 포함)
- [x] 성공 응답 시 세션 sliding 갱신(쿠키 + Redis TTL) 보완

#### 변경 내용
- 세션 재조회 후 이미 회전된 세션이면 즉시 반환
- 락 획득 요청만 refreshSessionViaSpring(...) 수행
- 락 미획득 요청은 polling 대기 후 갱신 세션 재조회
- timeout 직전 최종 재조회 1회 수행은 실제 rotation 호출 primitive로 유지
- 401 refresh 분기에서 refreshSessionViaSpring(...) → refreshSessionWithSingleFlight(...)로 교체
- 기존 업스트림 1회 재시도 로직은 유지
- 성공 응답 시 slideSession(...)으로 Redis TTL + sessionId 쿠키 maxAge 동시 갱신


### 테스트/검증
- [x] 동시 401 상황에서 refresh가 세션당 1회만 수행되는지
- [x] 대기 요청이 갱신된 세션으로 업스트림 재시도 성공하는지
- [x] refresh 실패 시 기존 정책대로 세션 삭제 + 401 처리되는지