### PR TITLE
fix: 홈/채팅 검색, AI 직무 요약 UX 개선 (Close #148)

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -168,7 +168,7 @@ export default function HomePage() {
       {/* 검색창 */}
       <div className="px-6 py-4">
         <SearchInput
-          placeholder={`검색어를 입력하세요(최대 ${SEARCH_MAX_LENGTH}자)`}
+          placeholder={`검색어를 입력하세요.`}
           maxLength={SEARCH_MAX_LENGTH}
           value={keyword}
           onChange={(e) => handleSearch(e.target.value)}
@@ -178,7 +178,7 @@ export default function HomePage() {
           onBlur={() => setIsSearchInputFocused(false)}
           className={cn(
             isSearchLimitFeedback &&
-              'animate-search-limit-shake [&_input]:!border-destructive [&_input]:bg-destructive/5 [&_input]:focus:!border-destructive [&_input]:focus:!ring-destructive/30 [&_svg]:text-destructive'
+            'animate-search-limit-shake [&_input]:!border-destructive [&_input]:bg-destructive/5 [&_input]:focus:!border-destructive [&_input]:focus:!ring-destructive/30 [&_svg]:text-destructive'
           )}
         />
         {isSearchInputFocused && (

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -18,11 +18,19 @@ import { useWallets, useDeleteWalletCard } from '@/features/home/api'
 import { useRouter } from 'next/navigation'
 import { IconButton, toast } from '@/shared'
 import { ocrFlowAtom, type OcrMode } from '@/features/ocr'
+import { cn } from '@/lib/utils'
+
+const SEARCH_MAX_LENGTH = 100
 
 export default function HomePage() {
   const [fabOpen, setFabOpen] = React.useState(false)
   const [keyword, setKeyword] = React.useState('')
+  const [isSearchInputFocused, setIsSearchInputFocused] = React.useState(false)
+  const [isSearchLimitFeedback, setIsSearchLimitFeedback] = React.useState(false)
   const [isOcrModeDialogOpen, setIsOcrModeDialogOpen] = React.useState(false)
+  const searchLimitFeedbackTimeoutRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
   const [, setOcrFlow] = useAtom(ocrFlowAtom)
   const router = useRouter()
 
@@ -68,7 +76,60 @@ export default function HomePage() {
   }
 
   const handleSearch = (value: string) => {
-    setKeyword(value)
+    setKeyword(value.slice(0, SEARCH_MAX_LENGTH))
+  }
+
+  const triggerSearchLimitFeedback = React.useCallback(() => {
+    setIsSearchLimitFeedback(false)
+    requestAnimationFrame(() => {
+      setIsSearchLimitFeedback(true)
+    })
+
+    if (searchLimitFeedbackTimeoutRef.current) {
+      clearTimeout(searchLimitFeedbackTimeoutRef.current)
+    }
+
+    searchLimitFeedbackTimeoutRef.current = setTimeout(() => {
+      setIsSearchLimitFeedback(false)
+    }, 320)
+  }, [])
+
+  React.useEffect(() => {
+    return () => {
+      if (searchLimitFeedbackTimeoutRef.current) {
+        clearTimeout(searchLimitFeedbackTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) return
+    if (event.ctrlKey || event.metaKey || event.altKey) return
+    if (event.key.length !== 1) return
+
+    const input = event.currentTarget
+    const selectionStart = input.selectionStart ?? 0
+    const selectionEnd = input.selectionEnd ?? selectionStart
+    const nextLength = keyword.length - (selectionEnd - selectionStart) + 1
+
+    if (nextLength > SEARCH_MAX_LENGTH) {
+      triggerSearchLimitFeedback()
+    }
+  }
+
+  const handleSearchPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    const pastedText = event.clipboardData.getData('text')
+    if (!pastedText) return
+
+    const input = event.currentTarget
+    const selectionStart = input.selectionStart ?? 0
+    const selectionEnd = input.selectionEnd ?? selectionStart
+    const nextLength =
+      keyword.length - (selectionEnd - selectionStart) + pastedText.length
+
+    if (nextLength > SEARCH_MAX_LENGTH) {
+      triggerSearchLimitFeedback()
+    }
   }
 
   const handleCardPress = (cardId: number, userId: number | null) => {
@@ -107,10 +168,29 @@ export default function HomePage() {
       {/* 검색창 */}
       <div className="px-6 py-4">
         <SearchInput
-          placeholder="검색어를 입력하세요."
+          placeholder={`검색어를 입력하세요(최대 ${SEARCH_MAX_LENGTH}자)`}
+          maxLength={SEARCH_MAX_LENGTH}
           value={keyword}
           onChange={(e) => handleSearch(e.target.value)}
+          onKeyDown={handleSearchKeyDown}
+          onPaste={handleSearchPaste}
+          onFocus={() => setIsSearchInputFocused(true)}
+          onBlur={() => setIsSearchInputFocused(false)}
+          className={cn(
+            isSearchLimitFeedback &&
+              'animate-search-limit-shake [&_input]:!border-destructive [&_input]:bg-destructive/5 [&_input]:focus:!border-destructive [&_input]:focus:!ring-destructive/30 [&_svg]:text-destructive'
+          )}
         />
+        {isSearchInputFocused && (
+          <p
+            className={cn(
+              'text-muted-foreground mt-1 text-right text-[11px]',
+              isSearchLimitFeedback && 'text-destructive'
+            )}
+          >
+            {keyword.length}/{SEARCH_MAX_LENGTH}자
+          </p>
+        )}
       </div>
 
       {/* 명함 목록 */}
@@ -123,6 +203,7 @@ export default function HomePage() {
           <EmptyCardPlaceholder
             onCreate={handleAddPaperCard}
             onImport={handleScanQR}
+            searchKeyword={keyword}
           />
         ) : (
           <BusinessCardList

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -26,7 +26,8 @@ export default function HomePage() {
   const [fabOpen, setFabOpen] = React.useState(false)
   const [keyword, setKeyword] = React.useState('')
   const [isSearchInputFocused, setIsSearchInputFocused] = React.useState(false)
-  const [isSearchLimitFeedback, setIsSearchLimitFeedback] = React.useState(false)
+  const [isSearchLimitFeedback, setIsSearchLimitFeedback] =
+    React.useState(false)
   const [isOcrModeDialogOpen, setIsOcrModeDialogOpen] = React.useState(false)
   const searchLimitFeedbackTimeoutRef = React.useRef<ReturnType<
     typeof setTimeout
@@ -102,7 +103,9 @@ export default function HomePage() {
     }
   }, [])
 
-  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleSearchKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
     if (event.nativeEvent.isComposing) return
     if (event.ctrlKey || event.metaKey || event.altKey) return
     if (event.key.length !== 1) return
@@ -178,7 +181,7 @@ export default function HomePage() {
           onBlur={() => setIsSearchInputFocused(false)}
           className={cn(
             isSearchLimitFeedback &&
-            'animate-search-limit-shake [&_input]:!border-destructive [&_input]:bg-destructive/5 [&_input]:focus:!border-destructive [&_input]:focus:!ring-destructive/30 [&_svg]:text-destructive'
+              'animate-search-limit-shake [&_input]:!border-destructive [&_input]:bg-destructive/5 [&_input]:focus:!border-destructive [&_input]:focus:!ring-destructive/30 [&_svg]:text-destructive'
           )}
         />
         {isSearchInputFocused && (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -247,3 +247,30 @@
 .animate-search-limit-shake {
   animation: search-limit-shake 320ms ease-in-out;
 }
+
+/* AI phase file transfer animation */
+@keyframes ai-file-transfer {
+  0% {
+    left: 0%;
+    opacity: 0;
+    transform: translate(-35%, -50%) scale(0.9);
+  }
+
+  14% {
+    opacity: 1;
+  }
+
+  86% {
+    opacity: 1;
+  }
+
+  100% {
+    left: 100%;
+    opacity: 0;
+    transform: translate(-65%, -50%) scale(0.96);
+  }
+}
+
+.animate-ai-file-transfer {
+  animation: ai-file-transfer 1200ms linear 1;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -219,3 +219,31 @@
 .animate-slide-up {
   animation: slide-up 1s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
+
+/* Search input limit feedback animation */
+@keyframes search-limit-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+
+  20% {
+    transform: translateX(-4px);
+  }
+
+  40% {
+    transform: translateX(4px);
+  }
+
+  60% {
+    transform: translateX(-3px);
+  }
+
+  80% {
+    transform: translateX(3px);
+  }
+}
+
+.animate-search-limit-shake {
+  animation: search-limit-shake 320ms ease-in-out;
+}

--- a/src/features/card-detail/ui/glass-card-preview.tsx
+++ b/src/features/card-detail/ui/glass-card-preview.tsx
@@ -158,7 +158,7 @@ function GlassCardPreview({
                             className={cn(
                               'flex size-7 shrink-0 items-center justify-center rounded-full border transition-colors',
                               isActive
-                                ? 'border-black bg-black text-[#BFAE9F] animate-pulse'
+                                ? 'animate-pulse border-black bg-black text-[#BFAE9F]'
                                 : 'border-black/20 bg-black/10 text-black/70'
                             )}
                           >
@@ -170,7 +170,7 @@ function GlassCardPreview({
                                 className={cn(
                                   'absolute top-1/2 left-0 -translate-y-1/2 text-black/75 opacity-0',
                                   isTransferSegment &&
-                                  'animate-ai-file-transfer opacity-100'
+                                    'animate-ai-file-transfer opacity-100'
                                 )}
                               >
                                 <FileTextIcon className="size-3.5" />
@@ -190,13 +190,14 @@ function GlassCardPreview({
                   <p className="font-inter text-[16px] leading-snug font-medium text-black">
                     AI 직무 분석 및 요약을 준비 중
                     <span className="ml-1 inline-flex items-center gap-1 align-middle">
-                      <span className="bg-black/75 inline-block size-1.5 rounded-full animate-bounce [animation-delay:0ms]" />
-                      <span className="bg-black/75 inline-block size-1.5 rounded-full animate-bounce [animation-delay:120ms]" />
-                      <span className="bg-black/75 inline-block size-1.5 rounded-full animate-bounce [animation-delay:240ms]" />
+                      <span className="inline-block size-1.5 animate-bounce rounded-full bg-black/75 [animation-delay:0ms]" />
+                      <span className="inline-block size-1.5 animate-bounce rounded-full bg-black/75 [animation-delay:120ms]" />
+                      <span className="inline-block size-1.5 animate-bounce rounded-full bg-black/75 [animation-delay:240ms]" />
                     </span>
                   </p>
                   <p className="font-inter text-[12px] leading-snug font-normal whitespace-pre-line text-black/80">
-                    반영까지 다소 시간이 걸릴 수 있으며,{"\n"} 경력 정보가 추가되거나 수정되면 분석이 진행됩니다.
+                    반영까지 다소 시간이 걸릴 수 있으며,{'\n'} 경력 정보가
+                    추가되거나 수정되면 분석이 진행됩니다.
                   </p>
                 </div>
               )

--- a/src/features/card-detail/ui/glass-card-preview.tsx
+++ b/src/features/card-detail/ui/glass-card-preview.tsx
@@ -1,6 +1,12 @@
 'use client'
 
 import * as React from 'react'
+import {
+  ScanSearchIcon,
+  BrainIcon,
+  ListChecksIcon,
+  FileTextIcon,
+} from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { type ProfileData } from '@/shared'
 import { Switch } from '@/components/ui/switch'
@@ -12,6 +18,29 @@ interface GlassCardPreviewProps extends React.HTMLAttributes<HTMLDivElement> {
   aiDescription?: string
 }
 
+const AI_PROGRESS_PHASE_ONE_READ_HOLD_MS = 700
+const AI_PROGRESS_PHASE_ONE_THINK_HOLD_MS = 1000
+const AI_PROGRESS_PHASE_ONE_ANALYZE_HOLD_MS = 1500
+const AI_FILE_TRANSFER_DURATION_MS = 1200
+const AI_PROGRESS_PHASE_TWO_DURATION_MS = 4000
+const AI_PROGRESS_PHASE_ONE_STEPS = [
+  {
+    id: 'read',
+    label: '작성해주신 경력을 확인하고 있어요.',
+    icon: ScanSearchIcon,
+  },
+  {
+    id: 'think',
+    label: '핵심 정보를 정리하고 있어요',
+    icon: BrainIcon,
+  },
+  {
+    id: 'analyze',
+    label: '경력을 분석해 결과를 만들고 있어요',
+    icon: ListChecksIcon,
+  },
+] as const
+
 function GlassCardPreview({
   data,
   isFlip = false,
@@ -22,8 +51,72 @@ function GlassCardPreview({
 }: GlassCardPreviewProps) {
   const displayData = data
   const showDescription = isFlip
-  const descriptionText =
-    aiDescription?.trim() || 'AI가 당신의 직무를 분석하고 있어요'
+  const descriptionText = aiDescription?.trim() || ''
+  const isAiDescriptionPending = !descriptionText
+  const [aiProgressPhase, setAiProgressPhase] = React.useState<1 | 2>(1)
+  const [phaseOneStepIndex, setPhaseOneStepIndex] = React.useState(0)
+  const [activeTransferSegment, setActiveTransferSegment] = React.useState<
+    number | null
+  >(null)
+
+  React.useEffect(() => {
+    if (!showDescription || !isAiDescriptionPending) return
+
+    setAiProgressPhase(1)
+    setPhaseOneStepIndex(0)
+    setActiveTransferSegment(null)
+
+    let isCancelled = false
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+    const wait = (ms: number) =>
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(() => {
+          resolve()
+        }, ms)
+      })
+
+    const runLoop = async () => {
+      while (!isCancelled) {
+        setAiProgressPhase(1)
+        setPhaseOneStepIndex(0)
+        setActiveTransferSegment(null)
+
+        await wait(AI_PROGRESS_PHASE_ONE_READ_HOLD_MS)
+        if (isCancelled) return
+
+        setActiveTransferSegment(0)
+        await wait(AI_FILE_TRANSFER_DURATION_MS)
+        if (isCancelled) return
+
+        setActiveTransferSegment(null)
+        setPhaseOneStepIndex(1)
+        await wait(AI_PROGRESS_PHASE_ONE_THINK_HOLD_MS)
+        if (isCancelled) return
+
+        setActiveTransferSegment(1)
+        await wait(AI_FILE_TRANSFER_DURATION_MS)
+        if (isCancelled) return
+
+        setActiveTransferSegment(null)
+        setPhaseOneStepIndex(2)
+        await wait(AI_PROGRESS_PHASE_ONE_ANALYZE_HOLD_MS)
+        if (isCancelled) return
+
+        setAiProgressPhase(2)
+        await wait(AI_PROGRESS_PHASE_TWO_DURATION_MS)
+      }
+    }
+
+    void runLoop()
+
+    return () => {
+      isCancelled = true
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+    }
+  }, [isAiDescriptionPending, showDescription])
 
   return (
     <div
@@ -50,9 +143,68 @@ function GlassCardPreview({
       <div className="mt-2">
         {showDescription ? (
           <div className="max-h-[76px] overflow-y-auto pr-1 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/20 hover:[&::-webkit-scrollbar-thumb]:bg-black/30 [&::-webkit-scrollbar-track]:bg-transparent">
-            <p className="font-inter text-[18px] leading-snug font-normal whitespace-pre-line text-black">
-              {descriptionText}
-            </p>
+            {isAiDescriptionPending ? (
+              aiProgressPhase === 1 ? (
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5">
+                    {AI_PROGRESS_PHASE_ONE_STEPS.map((step, index) => {
+                      const Icon = step.icon
+                      const isActive = index === phaseOneStepIndex
+                      const isTransferSegment = activeTransferSegment === index
+
+                      return (
+                        <React.Fragment key={step.id}>
+                          <div
+                            className={cn(
+                              'flex size-7 shrink-0 items-center justify-center rounded-full border transition-colors',
+                              isActive
+                                ? 'border-black bg-black text-[#BFAE9F] animate-pulse'
+                                : 'border-black/20 bg-black/10 text-black/70'
+                            )}
+                          >
+                            <Icon className="size-3.5" />
+                          </div>
+                          {index < AI_PROGRESS_PHASE_ONE_STEPS.length - 1 && (
+                            <div className="relative h-[2px] min-w-[26px] flex-1 overflow-visible rounded-full bg-black/25">
+                              <span
+                                className={cn(
+                                  'absolute top-1/2 left-0 -translate-y-1/2 text-black/75 opacity-0',
+                                  isTransferSegment &&
+                                  'animate-ai-file-transfer opacity-100'
+                                )}
+                              >
+                                <FileTextIcon className="size-3.5" />
+                              </span>
+                            </div>
+                          )}
+                        </React.Fragment>
+                      )
+                    })}
+                  </div>
+                  <p className="font-inter text-[12px] leading-snug font-normal text-black/85">
+                    {AI_PROGRESS_PHASE_ONE_STEPS[phaseOneStepIndex]?.label}
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  <p className="font-inter text-[16px] leading-snug font-medium text-black">
+                    AI 직무 분석 및 요약을 준비 중
+                    <span className="ml-1 inline-flex items-center gap-1 align-middle">
+                      <span className="bg-black/75 inline-block size-1.5 rounded-full animate-bounce [animation-delay:0ms]" />
+                      <span className="bg-black/75 inline-block size-1.5 rounded-full animate-bounce [animation-delay:120ms]" />
+                      <span className="bg-black/75 inline-block size-1.5 rounded-full animate-bounce [animation-delay:240ms]" />
+                    </span>
+                  </p>
+                  <p className="font-inter text-[12px] leading-snug font-normal whitespace-pre-line text-black/80">
+                    반영까지 다소 시간이 걸릴 수 있으며,{"\n"} 경력 정보가 추가되거나 수정되면 분석이 진행됩니다.
+                  </p>
+                </div>
+              )
+            ) : (
+              <p className="font-inter text-[18px] leading-snug font-normal whitespace-pre-line text-black">
+                {descriptionText}
+              </p>
+            )}
           </div>
         ) : (
           <div className="flex flex-col gap-0.5">

--- a/src/features/chat/ui/chat-room-list-page.tsx
+++ b/src/features/chat/ui/chat-room-list-page.tsx
@@ -6,12 +6,20 @@ import { SearchIcon, RefreshCcwIcon } from 'lucide-react'
 import { useInView } from 'react-intersection-observer'
 import { Header, Button, EmptyState } from '@/shared'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
 import { useChatRooms } from '../api'
 import { ChatRoomListItem } from './chat-room-list-item'
+
+const SEARCH_MAX_LENGTH = 50
 
 function ChatRoomListPage() {
   const router = useRouter()
   const [keyword, setKeyword] = React.useState('')
+  const [isSearchInputFocused, setIsSearchInputFocused] = React.useState(false)
+  const [isSearchLimitFeedback, setIsSearchLimitFeedback] = React.useState(false)
+  const searchLimitFeedbackTimeoutRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
   const { ref, inView } = useInView({ rootMargin: '200px' })
 
   const {
@@ -30,6 +38,63 @@ function ChatRoomListPage() {
     }
   }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage])
 
+  const handleKeywordChange = (value: string) => {
+    setKeyword(value.slice(0, SEARCH_MAX_LENGTH))
+  }
+
+  const triggerSearchLimitFeedback = React.useCallback(() => {
+    setIsSearchLimitFeedback(false)
+    requestAnimationFrame(() => {
+      setIsSearchLimitFeedback(true)
+    })
+
+    if (searchLimitFeedbackTimeoutRef.current) {
+      clearTimeout(searchLimitFeedbackTimeoutRef.current)
+    }
+
+    searchLimitFeedbackTimeoutRef.current = setTimeout(() => {
+      setIsSearchLimitFeedback(false)
+    }, 320)
+  }, [])
+
+  React.useEffect(() => {
+    return () => {
+      if (searchLimitFeedbackTimeoutRef.current) {
+        clearTimeout(searchLimitFeedbackTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) return
+    if (event.ctrlKey || event.metaKey || event.altKey) return
+    if (event.key.length !== 1) return
+
+    const input = event.currentTarget
+    const selectionStart = input.selectionStart ?? 0
+    const selectionEnd = input.selectionEnd ?? selectionStart
+    const nextLength = keyword.length - (selectionEnd - selectionStart) + 1
+
+    if (nextLength > SEARCH_MAX_LENGTH) {
+      triggerSearchLimitFeedback()
+    }
+  }
+
+  const handleSearchPaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    const pastedText = event.clipboardData.getData('text')
+    if (!pastedText) return
+
+    const input = event.currentTarget
+    const selectionStart = input.selectionStart ?? 0
+    const selectionEnd = input.selectionEnd ?? selectionStart
+    const nextLength =
+      keyword.length - (selectionEnd - selectionStart) + pastedText.length
+
+    if (nextLength > SEARCH_MAX_LENGTH) {
+      triggerSearchLimitFeedback()
+    }
+  }
+
   const filteredRooms = React.useMemo(() => {
     const normalized = keyword.trim().toLowerCase()
     if (!normalized) return rooms
@@ -46,16 +111,45 @@ function ChatRoomListPage() {
 
       <div className="pt-14">
         <div className="border-border border-b px-4 py-3">
-          <label className="relative block">
-            <SearchIcon className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+          <label
+            className={cn(
+              'relative block',
+              isSearchLimitFeedback && 'animate-search-limit-shake'
+            )}
+          >
+            <SearchIcon
+              className={cn(
+                'text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2',
+                isSearchLimitFeedback && 'text-destructive'
+              )}
+            />
             <Input
               value={keyword}
-              onChange={(event) => setKeyword(event.target.value)}
+              onChange={(event) => handleKeywordChange(event.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              onPaste={handleSearchPaste}
+              onFocus={() => setIsSearchInputFocused(true)}
+              onBlur={() => setIsSearchInputFocused(false)}
+              maxLength={SEARCH_MAX_LENGTH}
               placeholder="이름 검색"
-              className="h-10 rounded-full pl-9"
+              className={cn(
+                'h-10 rounded-full pl-9',
+                isSearchLimitFeedback &&
+                  '!border-destructive bg-destructive/5 focus-visible:!border-destructive focus-visible:!ring-destructive/30'
+              )}
               disabled={isLoading || isError}
             />
           </label>
+          {isSearchInputFocused && (
+            <p
+              className={cn(
+                'text-muted-foreground mt-1 text-right text-[11px]',
+                isSearchLimitFeedback && 'text-destructive'
+              )}
+            >
+              {keyword.length}/{SEARCH_MAX_LENGTH}자
+            </p>
+          )}
         </div>
 
         {isLoading ? (

--- a/src/features/chat/ui/chat-room-list-page.tsx
+++ b/src/features/chat/ui/chat-room-list-page.tsx
@@ -81,8 +81,16 @@ function ChatRoomListPage() {
         ) : filteredRooms.length === 0 ? (
           <div className="px-4 py-6">
             <EmptyState
-              title="채팅방이 없습니다"
-              description="새 대화를 시작하면 채팅방이 생성됩니다."
+              title={
+                keyword.trim()
+                  ? '검색 결과가 없습니다.'
+                  : '채팅방이 없습니다'
+              }
+              description={
+                keyword.trim()
+                  ? '이름을 다시 검색해보세요.'
+                  : '새 대화를 시작하면 채팅방이 생성됩니다.'
+              }
             />
           </div>
         ) : (

--- a/src/features/chat/ui/chat-room-list-page.tsx
+++ b/src/features/chat/ui/chat-room-list-page.tsx
@@ -16,7 +16,8 @@ function ChatRoomListPage() {
   const router = useRouter()
   const [keyword, setKeyword] = React.useState('')
   const [isSearchInputFocused, setIsSearchInputFocused] = React.useState(false)
-  const [isSearchLimitFeedback, setIsSearchLimitFeedback] = React.useState(false)
+  const [isSearchLimitFeedback, setIsSearchLimitFeedback] =
+    React.useState(false)
   const searchLimitFeedbackTimeoutRef = React.useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
@@ -65,7 +66,9 @@ function ChatRoomListPage() {
     }
   }, [])
 
-  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleSearchKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
     if (event.nativeEvent.isComposing) return
     if (event.ctrlKey || event.metaKey || event.altKey) return
     if (event.key.length !== 1) return
@@ -176,9 +179,7 @@ function ChatRoomListPage() {
           <div className="px-4 py-6">
             <EmptyState
               title={
-                keyword.trim()
-                  ? '검색 결과가 없습니다.'
-                  : '채팅방이 없습니다'
+                keyword.trim() ? '검색 결과가 없습니다.' : '채팅방이 없습니다'
               }
               description={
                 keyword.trim()

--- a/src/features/home/ui/empty-card-placeholder.tsx
+++ b/src/features/home/ui/empty-card-placeholder.tsx
@@ -37,7 +37,8 @@ function EmptyCardPlaceholder({
   const hasSearchKeyword = Boolean(searchKeyword?.trim())
 
   const resolvedTitle =
-    title || (hasSearchKeyword ? '검색 결과가 없습니다' : '보유한 명함이 없습니다')
+    title ||
+    (hasSearchKeyword ? '검색 결과가 없습니다' : '보유한 명함이 없습니다')
   const resolvedDescription =
     description ||
     (hasSearchKeyword

--- a/src/features/home/ui/empty-card-placeholder.tsx
+++ b/src/features/home/ui/empty-card-placeholder.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { QrCodeIcon, FolderOpenIcon } from 'lucide-react'
+import { QrCodeIcon, FolderOpenIcon, SearchXIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   Empty,
@@ -20,18 +20,29 @@ interface EmptyCardPlaceholderProps extends React.HTMLAttributes<HTMLDivElement>
   onAdd?: () => void
   title?: string
   description?: string
+  searchKeyword?: string
 }
 
 function EmptyCardPlaceholder({
   onCreate,
   onImport,
   onAdd,
-  title = '보유한 명함이 없습니다',
-  description = '명함을 공유받고 명함 관리를 시작해 보세요.',
+  title,
+  description,
+  searchKeyword,
   className,
   ...props
 }: EmptyCardPlaceholderProps) {
   const handleCreate = onCreate || onAdd
+  const hasSearchKeyword = Boolean(searchKeyword?.trim())
+
+  const resolvedTitle =
+    title || (hasSearchKeyword ? '검색 결과가 없습니다' : '보유한 명함이 없습니다')
+  const resolvedDescription =
+    description ||
+    (hasSearchKeyword
+      ? '다른 이름이나 회사명으로 다시 검색해 보세요.'
+      : '명함을 공유받고 명함 관리를 시작해 보세요.')
 
   return (
     <Empty
@@ -44,14 +55,25 @@ function EmptyCardPlaceholder({
       {...props}
     >
       <EmptyHeader className="gap-3">
-        <EmptyMedia variant="icon" className="bg-muted text-muted-foreground">
-          <FolderOpenIcon className="size-6" />
+        <EmptyMedia
+          variant="icon"
+          className={
+            hasSearchKeyword
+              ? 'bg-destructive/10 text-destructive'
+              : 'bg-muted text-muted-foreground'
+          }
+        >
+          {hasSearchKeyword ? (
+            <SearchXIcon className="size-6" />
+          ) : (
+            <FolderOpenIcon className="size-6" />
+          )}
         </EmptyMedia>
         <EmptyTitle className="text-foreground text-base font-semibold">
-          {title}
+          {resolvedTitle}
         </EmptyTitle>
         <EmptyDescription className="text-muted-foreground text-sm">
-          {description}
+          {resolvedDescription}
         </EmptyDescription>
       </EmptyHeader>
 

--- a/src/features/ocr/ui/ocr-failure-page.tsx
+++ b/src/features/ocr/ui/ocr-failure-page.tsx
@@ -14,6 +14,7 @@ function OcrFailurePage() {
         '다시 촬영해서 시도해 주세요.',
       ]}
       retryLabel="다시 촬영하기"
+      retryButtonVariant="outline"
       onRetry={() => router.replace('/ocr')}
     />
   )

--- a/src/features/ocr/ui/ocr-permission-page.tsx
+++ b/src/features/ocr/ui/ocr-permission-page.tsx
@@ -238,6 +238,7 @@ function OcrPermissionPage() {
           '다시 시도해주세요.',
         ]}
         retryLabel="다시 시도하기"
+        retryButtonVariant="outline"
         onRetry={handleFailureRetry}
       />
     )

--- a/src/features/qr-scan/ui/qr-scan-failure.tsx
+++ b/src/features/qr-scan/ui/qr-scan-failure.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import * as React from 'react'
-import { Button } from '@/shared'
+import { Button, type ButtonVariant } from '@/shared'
 
 interface QrScanFailureProps {
   onRetry?: () => void
   title?: string
   descriptionLines?: [string, string] | string[]
   retryLabel?: string
+  retryButtonVariant?: ButtonVariant
 }
 
 function QrScanFailure({
@@ -15,6 +16,7 @@ function QrScanFailure({
   title = 'Oops....',
   descriptionLines = ['QR 스캔에 실패하셨습니다.', '다시 시도해주세요.'],
   retryLabel = '다시 QR 인식하기',
+  retryButtonVariant = 'outline',
 }: QrScanFailureProps) {
   const [firstLine = '', secondLine = ''] = descriptionLines
 
@@ -34,9 +36,9 @@ function QrScanFailure({
 
       {/* 다시 QR 인식하기 버튼 */}
       <Button
-        variant="secondary"
+        variant={retryButtonVariant}
         fullWidth
-        className="mt-[105px] max-w-[334px] rounded-[10px] bg-[#ECECEC] text-[12px] font-medium tracking-[-0.24px]"
+        className="mt-[105px] max-w-[334px] rounded-[10px] text-[12px] font-medium tracking-[-0.24px]"
         onClick={onRetry}
       >
         {retryLabel}


### PR DESCRIPTION
  ### 제목(Title)

  fix: 홈/채팅 검색, AI 직무 요약 UX 개선

  ### 본문(Body)

  #### 요약
  - 홈/채팅 검색 입력 UX를 개선하고, AI 직무 요약이 아직 없는 상태에서의 로딩 표현을 단계형 애니메이션으로 추가했습니다.
  - 추가로 빈 상태 메시지 분기와 실패 페이지 버튼 스타일 일관성도 함께 정리했습니다.

  #### 완료 범위(필수)
  - 홈 검색창 입력 제한 및 초과 피드백(애니메이션/색상/카운터) 적용
  - 채팅방 검색 입력 UX 개선(입력 제한, 초과 피드백, 검색 결과 빈 상태 문구 분기)
  - 명함 미리보기에서 AI 직무 요약 대기 상태 애니메이션(2단계) 추가
  - 홈 빈 상태 컴포넌트 검색 문맥 대응
  - OCR/QR 실패 화면 버튼 variant 일관성 개선

  #### 변경 내용
  - src/app/(main)/home/page.tsx
      - 검색 최대 길이(100자) 제한
      - 키입력/붙여넣기 초과 시 shake + destructive 피드백
      - 포커스 시 문자 수 카운터 표시
      - 빈 목록 상태에 searchKeyword 전달로 검색 결과 없는 상태 분기
  - src/features/home/ui/empty-card-placeholder.tsx
      - 검색어 유무에 따라 아이콘/타이틀/설명 동적 변경
  - src/features/chat/ui/chat-room-list-page.tsx
      - 검색 최대 길이(50자) 제한 및 초과 피드백
      - 포커스 시 문자 수 카운터 표시
      - 검색어 존재 시 빈 상태 문구를 “검색 결과 없음”으로 분기
  - src/features/card-detail/ui/glass-card-preview.tsx
      - AI 설명 미생성 상태에서 단계형 진행 UI 추가
      - Phase 1: 읽기/정리/분석 단계 + 파일 이동 애니메이션
      - Phase 2: 요약 준비 중 메시지 + 점프 점 애니메이션
  - src/app/globals.css
      - search-limit-shake, ai-file-transfer keyframes 및 utility class 추가
  - src/features/qr-scan/ui/qr-scan-failure.tsx
      - retryButtonVariant prop 추가, 기본값 outline으로 변경
  - src/features/ocr/ui/ocr-failure-page.tsx
  - src/features/ocr/ui/ocr-permission-page.tsx
      - 실패 재시도 버튼 variant를 outline으로 명시해 스타일 통일

  #### 테스트/검증

  - 홈 검색 입력
      - 100자 초과 입력/붙여넣기 시 피드백(shake, 색상) 동작 확인
      - 포커스 상태에서 문자 수 카운터 노출 확인
      - 검색어 존재 + 결과 없음 상태에서 안내 문구/아이콘 변경 확인
  - 채팅 검색 입력
      - 50자 초과 입력/붙여넣기 피드백 동작 확인
      - 검색어 유무에 따른 EmptyState 타이틀/설명 분기 확인
  - 명함 미리보기
      - AI 설명 없을 때 Phase 1/2 로딩 애니메이션 순환 표시 확인
      - AI 설명 도착 시 실제 설명 텍스트로 전환 확인
  - OCR/QR 실패 화면
      - 재시도 버튼 스타일이 outline로 일관 적용되는지 확인