### PR TITLE
refactor: Kakao SDK 지연 로드 적용

### DIFF
--- a/src/app/(qr)/share/page.tsx
+++ b/src/app/(qr)/share/page.tsx
@@ -1,5 +1,11 @@
 import { QrSharePage } from '@/features/qr-share'
+import { KakaoScript } from '@/shared/kakao-script'
 
 export default function SharePage() {
-  return <QrSharePage />
+  return (
+    <>
+      <QrSharePage />
+      <KakaoScript />
+    </>
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import './globals.css'
-import { KakaoScript } from '@/shared/kakao-script'
 import { Providers } from './providers'
 
 export default function RootLayout({
@@ -15,7 +14,6 @@ export default function RootLayout({
             <main className="min-h-dvh w-full">{children}</main>
           </div>
         </Providers>
-        <KakaoScript />
       </body>
     </html>
   )

--- a/src/shared/kakao-script.tsx
+++ b/src/shared/kakao-script.tsx
@@ -1,10 +1,11 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import Script from 'next/script'
 
 declare global {
   interface Window {
-    Kakao: {
+    Kakao?: {
       isInitialized: () => boolean
       init: (appKey: string) => void
       Share: {
@@ -27,6 +28,51 @@ declare global {
 }
 
 function KakaoScript() {
+  const [shouldLoad, setShouldLoad] = useState(false)
+
+  useEffect(() => {
+    const appKey = process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY
+
+    if (window.Kakao) {
+      if (appKey && !window.Kakao.isInitialized()) {
+        window.Kakao.init(appKey)
+      }
+      return
+    }
+
+    let idleId: number | null = null
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
+    let scheduled = false
+
+    const scheduleLoad = () => {
+      if (scheduled) return
+      scheduled = true
+      setShouldLoad(true)
+
+      if (idleId !== null && window.cancelIdleCallback) {
+        window.cancelIdleCallback(idleId)
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+    }
+
+    if ('requestIdleCallback' in window) {
+      idleId = window.requestIdleCallback(scheduleLoad, { timeout: 2000 })
+    }
+
+    timeoutId = setTimeout(scheduleLoad, 150)
+
+    return () => {
+      if (idleId !== null && window.cancelIdleCallback) {
+        window.cancelIdleCallback(idleId)
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+    }
+  }, [])
+
   const onLoad = () => {
     const appKey = process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY
     if (appKey && window.Kakao && !window.Kakao.isInitialized()) {
@@ -34,10 +80,13 @@ function KakaoScript() {
     }
   }
 
+  if (!shouldLoad) return null
+
   return (
     <Script
+      id="kakao-sdk"
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.0/kakao.min.js"
-      async
+      strategy="afterInteractive"
       onLoad={onLoad}
     />
   )

--- a/src/shared/kakao-script.tsx
+++ b/src/shared/kakao-script.tsx
@@ -86,7 +86,7 @@ function KakaoScript() {
     <Script
       id="kakao-sdk"
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.0/kakao.min.js"
-      strategy="afterInteractive"
+      strategy="lazyOnload"
       onLoad={onLoad}
     />
   )


### PR DESCRIPTION
### 제목(Title)

refactor: Kakao SDK 지연 로드 적용 및 공유 페이지 스코프 한정

---

### 본문(Body)

#### 요약

전역 레이아웃에서 항상 로드되던 Kakao SDK를 제거하고, QR 공유 페이지에서만 지연 로드되도록 변경
초기 렌더 성능 영향을 줄이면서 기존 Kakao 초기화 동작은 유지

#### 완료 범위(필수)

- [x] RootLayout의 전역 Kakao SDK 주입 제거
- [x] 공유 페이지(/share)에서만 Kakao SDK 로드
- [x] KakaoScript에 idle/timeout 기반 지연 로드 로직 추가
- [x] SDK 중복 초기화 방지 및 기존 초기화 로직 유지

#### 변경 내용

- src/app/layout.tsx
- <KakaoScript /> 제거 (전역 로드 중단)
- src/app/(qr)/share/page.tsx
- <QrSharePage /> 하단에 <KakaoScript /> 주입
- Kakao SDK를 공유 페이지 진입 시에만 로드하도록 스코프 제한
- src/shared/kakao-script.tsx
- window.Kakao를 optional로 처리
- shouldLoad 상태 추가 후 useEffect에서 지연 로드 스케줄링
  - requestIdleCallback(..., { timeout: 2000 })
  - fallback setTimeout(150ms)
- 로드 전에는 null 반환
- Script 속성 정리
  - id="kakao-sdk"
  - strategy="lazyOnload"
- 로드 완료 시 app key 기반 Kakao.init 수행(미초기화 상태만)