### PR TITLE
feat: Redis Sentinel 도입 (Close #172)

### DIFF
--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -1,7 +1,23 @@
-export interface ServerEnv {
+export interface RedisSentinelNode {
+  host: string
+  port: number
+}
+
+export type RedisConfig =
+  | {
+      redisMode: 'standalone'
+      redisUrl: string
+    }
+  | {
+      redisMode: 'sentinel'
+      redisSentinelNodes: RedisSentinelNode[]
+      redisMasterName: string
+      redisPassword: string
+    }
+
+export type ServerEnv = RedisConfig & {
   springApiBaseUrl: string
   aiApiBaseUrl: string
-  redisUrl: string
   redisNamespace: string
   sessionCookieSecure: boolean
 
@@ -42,6 +58,77 @@ function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '')
 }
 
+function readTrimmedString(value: string | undefined): string {
+  return value?.trim() ?? ''
+}
+
+function parseRedisSentinelNodes(value: string): RedisSentinelNode[] {
+  const entries = value.split(',')
+
+  if (entries.length === 0 || entries.some((entry) => entry.trim() === '')) {
+    throw new Error(
+      'REDIS_SENTINEL_NODES must be a comma-separated list of host:port entries.'
+    )
+  }
+
+  return entries.map((entry) => {
+    const trimmedEntry = entry.trim()
+    const match = trimmedEntry.match(/^([^:]+):(\d+)$/)
+    const port = match ? Number.parseInt(match[2], 10) : Number.NaN
+
+    if (!match || !Number.isInteger(port) || port <= 0 || port > 65535) {
+      throw new Error(
+        'REDIS_SENTINEL_NODES must be a comma-separated list of host:port entries.'
+      )
+    }
+
+    return {
+      host: match[1],
+      port,
+    }
+  })
+}
+
+function readRedisConfig(): RedisConfig {
+  const appStage = readTrimmedString(process.env.APP_STAGE).toLowerCase()
+
+  if (appStage !== 'prod') {
+    const redisUrl = readTrimmedString(process.env.REDIS_URL)
+
+    if (!redisUrl) {
+      throw new Error('REDIS_URL is required for BFF session storage.')
+    }
+
+    return {
+      redisMode: 'standalone',
+      redisUrl,
+    }
+  }
+
+  const redisSentinelNodes = readTrimmedString(process.env.REDIS_SENTINEL_NODES)
+  const redisMasterName = readTrimmedString(process.env.REDIS_MASTER_NAME)
+  const redisPassword = readTrimmedString(process.env.REDIS_PASSWORD)
+
+  if (!redisSentinelNodes) {
+    throw new Error('REDIS_SENTINEL_NODES is required for prod BFF session storage.')
+  }
+
+  if (!redisMasterName) {
+    throw new Error('REDIS_MASTER_NAME is required for prod BFF session storage.')
+  }
+
+  if (!redisPassword) {
+    throw new Error('REDIS_PASSWORD is required for prod BFF session storage.')
+  }
+
+  return {
+    redisMode: 'sentinel',
+    redisSentinelNodes: parseRedisSentinelNodes(redisSentinelNodes),
+    redisMasterName,
+    redisPassword,
+  }
+}
+
 export function getServerEnv(): ServerEnv {
   const springApiBaseUrl = process.env.SPRING_API_BASE_URL || ''
 
@@ -49,15 +136,10 @@ export function getServerEnv(): ServerEnv {
     throw new Error('SPRING_API_BASE_URL is required for BFF routes.')
   }
 
-  const redisUrl = process.env.REDIS_URL || ''
-  if (!redisUrl) {
-    throw new Error('REDIS_URL is required for BFF session storage.')
-  }
-
   return {
+    ...readRedisConfig(),
     springApiBaseUrl: trimTrailingSlash(springApiBaseUrl),
     aiApiBaseUrl: trimTrailingSlash(process.env.AI_API_BASE_URL || ''),
-    redisUrl,
     redisNamespace: process.env.REDIS_NAMESPACE || DEFAULT_REDIS_NAMESPACE,
     sessionCookieSecure: readBoolean(
       process.env.SESSION_COOKIE_SECURE,

--- a/src/server/config/env.ts
+++ b/src/server/config/env.ts
@@ -110,11 +110,15 @@ function readRedisConfig(): RedisConfig {
   const redisPassword = readTrimmedString(process.env.REDIS_PASSWORD)
 
   if (!redisSentinelNodes) {
-    throw new Error('REDIS_SENTINEL_NODES is required for prod BFF session storage.')
+    throw new Error(
+      'REDIS_SENTINEL_NODES is required for prod BFF session storage.'
+    )
   }
 
   if (!redisMasterName) {
-    throw new Error('REDIS_MASTER_NAME is required for prod BFF session storage.')
+    throw new Error(
+      'REDIS_MASTER_NAME is required for prod BFF session storage.'
+    )
   }
 
   if (!redisPassword) {

--- a/src/server/redis/client.ts
+++ b/src/server/redis/client.ts
@@ -7,13 +7,24 @@ declare global {
 }
 
 function createRedisClient(): Redis {
-  const { redisUrl } = getServerEnv()
-
-  return new Redis(redisUrl, {
+  const env = getServerEnv()
+  const commonOptions = {
     maxRetriesPerRequest: 1,
     enableReadyCheck: true,
     lazyConnect: false,
-  })
+  }
+
+  if (env.redisMode === 'sentinel') {
+    return new Redis({
+      ...commonOptions,
+      sentinels: env.redisSentinelNodes,
+      name: env.redisMasterName,
+      password: env.redisPassword,
+      db: 0,
+    })
+  }
+
+  return new Redis(env.redisUrl, commonOptions)
 }
 
 export function getRedisClient(): Redis {


### PR DESCRIPTION

• ### 제목(Title)

feat: Redis Sentinel 도입

  ### 본문(Body)

  #### 요약

  hotfix/sentinel 브랜치의 변경사항은 Redis 연결 방식을
  standalone/sentinel 모드로 분기하도록 개선한 내용입니다.
  운영(APP_STAGE=prod) 환경에서 Sentinel 기반으로 세션/캐시 Redis
  에 연결할 수 있도록 서버 설정과 클라이언트 초기화를 확장했습니
  다.

  #### 완료 범위(필수)

  - Redis 환경설정 타입을 mode 기반으로 확장
  - APP_STAGE 기준 Redis 설정 분기 로직 추가
  - prod 환경 Sentinel 필수 env 검증 추가
  - Redis 클라이언트 생성 시 Sentinel 옵션 연결 지원

  #### 변경 내용

  - src/server/config/env.ts
      - ServerEnv를 RedisConfig 유니온 기반으로 재구성
      - redisMode: 'standalone' | 'sentinel' 추가
      - Sentinel 설정 파싱/검증 로직 추가
          - REDIS_SENTINEL_NODES (host:port,host:port 형식)
          - REDIS_MASTER_NAME
          - REDIS_PASSWORD
      - APP_STAGE !== 'prod'에서는 기존 REDIS_URL(standalone) 사
        용
      - APP_STAGE === 'prod'에서는 Sentinel 필수값 누락 시 에러
        처리
  - src/server/redis/client.ts
      - 공통 Redis 옵션 추출
      - redisMode === 'sentinel'일 때 new Redis({ sentinels,
        name, password, db: 0, ... })로 연결
      - 그 외는 기존 redisUrl 기반 standalone 연결 유지

  #### 테스트/검증

  - 로컬/개발(APP_STAGE!=prod)
      - REDIS_URL 설정 시 기존 방식으로 정상 연결 확인
  - 운영(APP_STAGE=prod)
      - REDIS_SENTINEL_NODES, REDIS_MASTER_NAME, REDIS_PASSWORD
        설정 시 정상 연결 확인
      - Sentinel env 누락/형식 오류 시 명확한 예외 메시지 확인
  - 세션/Redis 사용 기능 회귀 확인 (로그인 세션 조회/갱신/삭제)